### PR TITLE
Fix parsing DBC with 29-bit IDs

### DIFF
--- a/reader/src/main/java/com/rusefi/can/reader/dbc/DbcFile.java
+++ b/reader/src/main/java/com/rusefi/can/reader/dbc/DbcFile.java
@@ -68,8 +68,8 @@ public class DbcFile {
                 }
                 if (tokens.length < 4)
                     throw new IllegalStateException("Failing to parse comment: " + line + " at " + lineIndex);
-                int id = Integer.parseInt(tokens[2]);
-                DbcPacket packet = findPacket(id);
+                long id = Long.parseLong(tokens[2]) & 0x1FFFFFFF;    // strip ExtID flag if any
+                DbcPacket packet = findPacket((int)id);
                 Objects.requireNonNull(packet, "packet for " + id);
                 String originalName = tokens[3];
                 String niceName = merge(tokens, 4);
@@ -107,11 +107,8 @@ public class DbcFile {
             // skipping header line
             return currentPacket;
         }
-        long decId = Long.parseLong(tokens[1]);
-        if (decId > 2_000_000_000) {
-            System.err.println("Huh? Skipping ID=" + decId);
-            return currentPacket;
-        }
+        long decId = Long.parseLong(tokens[1]) & 0x1FFFFFFF;    // strip ExtID flag if any
+
         String packetName = tokens[2];
         currentPacket = new DbcPacketBuilder((int) decId, packetName);
         return currentPacket;


### PR DESCRIPTION
As I found in GMLAN dbc, all 29-bit packet IDs have flag 'Extended ID' in the most significant bit.

Let's say, `BO_ 2152480768 Perfr_Data_Recorder_Lap_Info_LS: 6 LVMPC_LS`
2152480768 = 0x804C4000, packet ID itself is a 0x004C4000

The easiest way to deal with it - just strip excessive bits.