### PR TITLE
Add support for GMLAN long identifiers

### DIFF
--- a/reader/src/main/java/com/rusefi/can/Launcher.java
+++ b/reader/src/main/java/com/rusefi/can/Launcher.java
@@ -12,8 +12,12 @@ public class Launcher {
     public static String fileNameFilter;
     public static final String DBC_FILENAME_PROPERTY = "-dbc";
     public static String dbcFileName;
-    public static final String DBC_DUP_FIELD_NAMES = "-allow-dup-names";
+    private static final String DBC_DUP_FIELD_NAMES = "-allow-dup-names";
     public static boolean allowDuplicateNames = false;
+
+    // lower 13 bits in GMLAN IDs is a sender address. DBC may contain the only zeros in this field
+    private static final String GMLAN_IGNORE_SENDER = "-gmlan-ignore-sender";
+    public static boolean gmlanIgnoreSender = false;
 
     public static void main(String[] args) throws IOException {
         if (args.length < 1) {
@@ -23,6 +27,7 @@ public class Launcher {
                     FILENAME_FILTER_PROPERTY,
                     DBC_FILENAME_PROPERTY,
                     DBC_DUP_FIELD_NAMES,
+                    GMLAN_IGNORE_SENDER,
             }));
             System.exit(-1);
         }
@@ -43,6 +48,9 @@ public class Launcher {
                 case DBC_FILENAME_PROPERTY:
                     i += 1;
                     dbcFileName = args[i];
+                    break;
+                case GMLAN_IGNORE_SENDER:
+                    gmlanIgnoreSender = true;
                     break;
                 default:
                     throw new IllegalStateException("Unexpected argument " + args[i]);

--- a/reader/src/main/java/com/rusefi/can/reader/dbc/DbcFile.java
+++ b/reader/src/main/java/com/rusefi/can/reader/dbc/DbcFile.java
@@ -145,7 +145,7 @@ public class DbcFile {
     }
 
     public DbcPacket findPacket(int canId) {
-        return packets.get(canId);
+        return packets.get(trimSid(canId));
     }
 
     public List<BinaryLogEntry> getFieldNameEntries(LoggingStrategy.LoggingFilter filter) {
@@ -160,7 +160,8 @@ public class DbcFile {
     }
 
     public DbcPacket getPacket(int sid) {
-        return packets.computeIfAbsent(sid, new Function<Integer, DbcPacket>() {
+        int trimmedSid = trimSid(sid);
+        return packets.computeIfAbsent(trimmedSid, new Function<Integer, DbcPacket>() {
             @Override
             public DbcPacket apply(Integer integer) {
                 String packetName = Integer.toHexString(sid) + "_" + sid;
@@ -170,11 +171,15 @@ public class DbcFile {
         });
     }
 
-    public DbcPacket get(int sid) {
-        return packets.get(sid);
-    }
-
     public Collection<DbcPacket> values() {
         return packets.values();
+    }
+
+    // GMLAN specific: leave the only ArbID, trim priority and sender fields
+    static private int trimSid(int sid) {
+        if (Launcher.gmlanIgnoreSender && (sid > 0x7FF))
+            return (sid & 0x03FF_FE00);
+        else
+            return sid;
     }
 }

--- a/reader/src/test/java/com/rusefi/can/reader/impl/ParseDBCTest.java
+++ b/reader/src/test/java/com/rusefi/can/reader/impl/ParseDBCTest.java
@@ -126,7 +126,7 @@ public class ParseDBCTest {
         dbc.read(reader);
 
         assertEquals(dbc.size(), 1);
-        DbcPacket packet = dbc.get(100);
+        DbcPacket packet = dbc.findPacket(100);
         assertNotNull(packet);
 
         DbcField f = packet.getFields().get(0);

--- a/reader/src/test/java/com/rusefi/can/reader/impl/ParseDBCWithCommentTest.java
+++ b/reader/src/test/java/com/rusefi/can/reader/impl/ParseDBCWithCommentTest.java
@@ -63,7 +63,7 @@ public class ParseDBCWithCommentTest {
         dbc.read(reader);
 
         assertEquals(dbc.size(), 1);
-        DbcPacket packet = dbc.get(1408);
+        DbcPacket packet = dbc.findPacket(1408);
         DbcField field = packet.find("Number of cylinders");
         assertNotNull(field);
         assertTrue(field.isNiceName());
@@ -78,7 +78,7 @@ public class ParseDBCWithCommentTest {
         DbcFile dbc = new DbcFile(false);
         dbc.read(reader);
         assertEquals(dbc.size(), 1);
-        DbcPacket p190 = dbc.get(190);
+        DbcPacket p190 = dbc.findPacket(190);
         DbcField signalBrkPdl = p190.getByName("PSBPI_PTSnBrkPdlPs");
         assertEquals(8, signalBrkPdl.getStartOffset());
         assertEquals(8, signalBrkPdl.getLength());
@@ -97,7 +97,7 @@ public class ParseDBCWithCommentTest {
         dbc.read(reader);
         assertEquals(dbc.size(), 1);
 
-        DbcPacket p190 = dbc.get(190);
+        DbcPacket p190 = dbc.findPacket(190);
         assertEquals(9, p190.getFields().size());
 
         DbcField firstByte = p190.findByBitIndex(/*bit index*/3);


### PR DESCRIPTION
GMLAN Bible says that packet identifiers contains a few fields: priority, arbitrary id and sender.

Priority and sender are empty in the PlatformA DBC (and mine own as well) for all packets.
This patch will allow to match corresponding packets, even these fields have some value (as we have in real traces).