### PR TITLE
Rework filtering in the MegaLog export to support GMLan long IDs

### DIFF
--- a/reader/src/main/java/com/rusefi/can/reader/dbc/DbcFile.java
+++ b/reader/src/main/java/com/rusefi/can/reader/dbc/DbcFile.java
@@ -176,7 +176,7 @@ public class DbcFile {
     }
 
     // GMLAN specific: leave the only ArbID, trim priority and sender fields
-    static private int trimSid(int sid) {
+    static public int trimSid(int sid) {
         if (Launcher.gmlanIgnoreSender && (sid > 0x7FF))
             return (sid & 0x03FF_FE00);
         else

--- a/reader/src/main/java/com/rusefi/can/reader/dbc/DbcPacket.java
+++ b/reader/src/main/java/com/rusefi/can/reader/dbc/DbcPacket.java
@@ -1,8 +1,11 @@
 package com.rusefi.can.reader.dbc;
 
+import com.rusefi.can.Launcher;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Packet describes all the fields for specific can ID
@@ -122,5 +125,18 @@ public class DbcPacket {
                 return field;
         }
         return null;
+    }
+
+    public boolean isInLog(Set<Integer> sidList) {
+        if (Launcher.gmlanIgnoreSender) {
+            for (int sid : sidList) {
+                if (DbcFile.trimSid(sid) == getId())
+                    return true;
+            }
+            return false;
+        }
+        else {
+            return sidList.contains(getId());
+        }
     }
 }

--- a/reader/src/main/java/com/rusefi/mlv/LoggingStrategy.java
+++ b/reader/src/main/java/com/rusefi/mlv/LoggingStrategy.java
@@ -38,7 +38,7 @@ public class LoggingStrategy {
     public static void writeLogByDbc(DbcFile dbc, List<CANPacket> packets, String outputFileName) {
         Set<Integer> allIds = CANPacket.getAllIds(packets);
         // we only log DBC frames if at least one packet is present in the trace
-        LoggingFilter filter = packet -> allIds.contains(packet.getId());
+        LoggingFilter filter = packet -> packet.isInLog(allIds);
         List<BinaryLogEntry> entries = dbc.getFieldNameEntries(filter);
 
         System.out.println(new Date() + " writeLog... " + outputFileName);


### PR DESCRIPTION
Added MLG export for GMLAN specific IDs (DBC file contains the only part of the real ID from log)

`isInLog()` is not the best name, but I don't know how to call it better