### PR TITLE
J1939mode

### DIFF
--- a/reader/src/main/java/com/rusefi/can/Launcher.java
+++ b/reader/src/main/java/com/rusefi/can/Launcher.java
@@ -19,6 +19,10 @@ public class Launcher {
     private static final String GMLAN_IGNORE_SENDER = "-gmlan-ignore-sender";
     public static boolean gmlanIgnoreSender = false;
 
+    // J1939: lower 8 bits are sender, higher 3 bits - Priority. DBC contains weird 'FE' in these fields
+    private static final String J1939_MODE = "-j1939-mode";
+    public static boolean j1939_mode = false;
+
     public static void main(String[] args) throws IOException {
         if (args.length < 1) {
             System.err.println("At least folder name is expected");
@@ -28,6 +32,7 @@ public class Launcher {
                     DBC_FILENAME_PROPERTY,
                     DBC_DUP_FIELD_NAMES,
                     GMLAN_IGNORE_SENDER,
+                    J1939_MODE
             }));
             System.exit(-1);
         }
@@ -51,6 +56,9 @@ public class Launcher {
                     break;
                 case GMLAN_IGNORE_SENDER:
                     gmlanIgnoreSender = true;
+                    break;
+                case J1939_MODE:
+                    j1939_mode = true;
                     break;
                 default:
                     throw new IllegalStateException("Unexpected argument " + args[i]);

--- a/reader/src/main/java/com/rusefi/can/reader/dbc/DbcFile.java
+++ b/reader/src/main/java/com/rusefi/can/reader/dbc/DbcFile.java
@@ -108,9 +108,9 @@ public class DbcFile {
             return currentPacket;
         }
         long decId = Long.parseLong(tokens[1]) & 0x1FFFFFFF;    // strip ExtID flag if any
-
+        int trimmedId = trimSid((int) decId);
         String packetName = tokens[2];
-        currentPacket = new DbcPacketBuilder((int) decId, packetName);
+        currentPacket = new DbcPacketBuilder(trimmedId, packetName);
         return currentPacket;
     }
 
@@ -130,8 +130,12 @@ public class DbcFile {
                 return;
             int sid = currentPacket.getPacketId();
             DbcPacket existingPacket = packets.get(sid);
-            if (existingPacket != null)
-                throw new IllegalStateException("We already have " + existingPacket.getName() + " for " + sid);
+            if (existingPacket != null) {
+                //throw new IllegalStateException("We already have " + existingPacket.getName() + " for " + sid);
+                currentPacket.markConsumed();
+                System.err.println("Packets conflict: " + existingPacket.getName() + " and " + currentPacket.getPacketName() +
+                    " have the same ID = " + sid);
+            }
             List<DbcField> signals = new GapFactory(currentPacket.getSignals(), currentPacket.getPacketName()).withGaps(sid);
             packets.put(sid, new DbcPacket(sid, currentPacket.getPacketName(), signals));
             currentPacket.markConsumed();
@@ -176,9 +180,18 @@ public class DbcFile {
     }
 
     // GMLAN specific: leave the only ArbID, trim priority and sender fields
+    // J1939 specific: trim source and destination (if any)
     static public int trimSid(int sid) {
-        if (Launcher.gmlanIgnoreSender && (sid > 0x7FF))
+        boolean longId = (sid > 0x7FF);
+        if (Launcher.gmlanIgnoreSender && longId)
             return (sid & 0x03FF_FE00);
+        else if (Launcher.j1939_mode && longId) {
+            int pduFormat = (sid >> 16) & 0xFF;
+            if (pduFormat < 0xF0) // PDU1 - peer to peer
+                return (sid & 0x03FF_0000);
+            else // PDU2 - broadcast
+                return (sid & 0x03FF_FF00);
+        }
         else
             return sid;
     }

--- a/reader/src/main/java/com/rusefi/can/reader/dbc/DbcFile.java
+++ b/reader/src/main/java/com/rusefi/can/reader/dbc/DbcFile.java
@@ -73,7 +73,7 @@ public class DbcFile {
                 Objects.requireNonNull(packet, "packet for " + id);
                 String originalName = tokens[3];
                 String niceName = merge(tokens, 4);
-                packet.replaceName(originalName, niceName);
+                packet.addComment(originalName, niceName);
 
 
             } else if (line.startsWith("SG_ ")) {

--- a/reader/src/main/java/com/rusefi/can/reader/dbc/DbcPacket.java
+++ b/reader/src/main/java/com/rusefi/can/reader/dbc/DbcPacket.java
@@ -50,7 +50,7 @@ public class DbcPacket {
         return null;
     }
 
-    public void replaceName(String originalName, String niceName) {
+    public void addComment(String originalName, String niceName) {
         if (niceName.charAt(niceName.length() - 1) == ';')
             niceName = niceName.substring(0, niceName.length() - 1);
         niceName = unquote(niceName);
@@ -59,8 +59,8 @@ public class DbcPacket {
             System.err.println("Field not found by [" + originalName + "]");
             return;
         }
-        Objects.requireNonNull(field, "By " + originalName);
-        field.rename(niceName);
+
+        field.rename(originalName + ": " + niceName);
     }
 
     private static String unquote(String q) {

--- a/reader/src/main/java/com/rusefi/can/reader/dbc/DbcPacket.java
+++ b/reader/src/main/java/com/rusefi/can/reader/dbc/DbcPacket.java
@@ -80,8 +80,8 @@ public class DbcPacket {
                         break;
                     case '\\':
                     case '\"':
-                    case '*':
-                    case '?':
+                    //case '*':
+                    //case '?':
                         break;
                     default:
                         throw new IllegalArgumentException(
@@ -89,8 +89,8 @@ public class DbcPacket {
                 }
             } else {
                 switch (c) {
-                    case '*':
-                    case '?':
+                    //case '*':
+                    //case '?':
                     case '\"':
                     case '\n':
                         throw new IllegalArgumentException(
@@ -128,7 +128,7 @@ public class DbcPacket {
     }
 
     public boolean isInLog(Set<Integer> sidList) {
-        if (Launcher.gmlanIgnoreSender) {
+        if (Launcher.gmlanIgnoreSender || Launcher.j1939_mode) {
             for (int sid : sidList) {
                 if (DbcFile.trimSid(sid) == getId())
                     return true;

--- a/reader/src/main/java/com/rusefi/can/reader/dbc/GapFactory.java
+++ b/reader/src/main/java/com/rusefi/can/reader/dbc/GapFactory.java
@@ -20,7 +20,9 @@ public class GapFactory {
                 try {
                     isUsed[bitIndex] = true;
                 } catch (ArrayIndexOutOfBoundsException e) {
-                    throw new IllegalStateException("While " + packetName + " " + dbcField, e);
+                    //throw new IllegalStateException("While " + packetName + " " + dbcField, e);
+                    System.err.println("Too long indexes in " + packetName + " " + dbcField);
+                    break;
                 }
             }
         }

--- a/reader/src/test/java/com/rusefi/can/reader/impl/J1939modeTest.java
+++ b/reader/src/test/java/com/rusefi/can/reader/impl/J1939modeTest.java
@@ -21,30 +21,30 @@ import static org.junit.Assert.*;
 public class J1939modeTest {
 
     // xxF004xx
-    private static final String dbcEEC = """
-    BO_ 2364540158 EEC1: 8 Vector__XXX
-        SG_ EngDemandPercentTorque : 56|8@1+ (1,-125) [-125|125] "%" Vector__XXX
-        SG_ EngStarterMode : 48|4@1+ (1,0) [0|15] "" Vector__XXX
-        SG_ SrcAddrssOfCntrllngDvcForEngCtrl : 40|8@1+ (1,0) [0|253] "" Vector__XXX
-        SG_ EngSpeed : 24|16@1+ (0.125,0) [0|8031.875] "rpm" Vector__XXX
-        SG_ ActualEngPercentTorque : 16|8@1+ (1,-125) [0|125] "%" Vector__XXX
-        SG_ DriversDemandEngPercentTorque : 8|8@1+ (1,-125) [0|125] "%" Vector__XXX
-        SG_ ActlEngPrcntTorqueHighResolution : 4|4@1+ (0.125,0) [0|0.875] "%" Vector__XXX
-        SG_ EngTorqueMode : 0|4@1+ (1,0) [0|15] "" Vector__XXX""";
+    private static final String dbcEEC =
+		"BO_ 2364540158 EEC1: 8 Vector__XXX\n" +
+		"    SG_ EngDemandPercentTorque : 56|8@1+ (1,-125) [-125|125] \"%\" Vector__XXX\n" +
+		"    SG_ EngStarterMode : 48|4@1+ (1,0) [0|15] \"\" Vector__XXX\n" +
+		"    SG_ SrcAddrssOfCntrllngDvcForEngCtrl : 40|8@1+ (1,0) [0|253] \"\" Vector__XXX\n" +
+		"    SG_ EngSpeed : 24|16@1+ (0.125,0) [0|8031.875] \"rpm\" Vector__XXX\n" +
+		"    SG_ ActualEngPercentTorque : 16|8@1+ (1,-125) [0|125] \"%\" Vector__XXX\n" +
+		"    SG_ DriversDemandEngPercentTorque : 8|8@1+ (1,-125) [0|125] \"%\" Vector__XXX\n" +
+		"    SG_ ActlEngPrcntTorqueHighResolution : 4|4@1+ (0.125,0) [0|0.875] \"%\" Vector__XXX\n" +
+		"    SG_ EngTorqueMode : 0|4@1+ (1,0) [0|15] \"\" Vector__XXX\n";
 
     // xxF013xx
-    private static final String dbcSSI = """
-    BO_ 2364543998 SSI: 8 Vector__XXX
-        SG_ RollAndPitchMeasurementLatency : 56|8@1+ (0.5,0) [0|125] "ms" Vector__XXX
-        SG_ PitchAndRollCompensated : 54|2@1+ (1,0) [0|3] "" Vector__XXX
-        SG_ PitchRateFigureOfMerit : 52|2@1+ (1,0) [0|3] "" Vector__XXX
-        SG_ RollAngleFigureOfMerit : 50|2@1+ (1,0) [0|3] "" Vector__XXX
-        SG_ PitchAngleFigureOfMerit : 48|2@1+ (1,0) [0|3] "" Vector__XXX
-        SG_ PitchRate : 32|16@1+ (0.002,-64) [-64|64.51] "deg/s" Vector__XXX
-        SG_ RollAngle : 16|16@1+ (0.002,-64) [-64|64.51] "deg" Vector__XXX
-        SG_ PitchAngle : 0|16@1+ (0.002,-64) [-64|64.51] "deg" Vector__XXX""";
+    private static final String dbcSSI =
+		"BO_ 2364543998 SSI: 8 Vector__XXX\n" +
+		"    SG_ RollAndPitchMeasurementLatency : 56|8@1+ (0.5,0) [0|125] \"ms\" Vector__XXX\n" +
+		"    SG_ PitchAndRollCompensated : 54|2@1+ (1,0) [0|3] \"\" Vector__XXX\n" +
+		"    SG_ PitchRateFigureOfMerit : 52|2@1+ (1,0) [0|3] \"\" Vector__XXX\n" +
+		"    SG_ RollAngleFigureOfMerit : 50|2@1+ (1,0) [0|3] \"\" Vector__XXX\n" +
+		"    SG_ PitchAngleFigureOfMerit : 48|2@1+ (1,0) [0|3] \"\" Vector__XXX\n" +
+		"    SG_ PitchRate : 32|16@1+ (0.002,-64) [-64|64.51] \"deg/s\" Vector__XXX\n" +
+		"    SG_ RollAngle : 16|16@1+ (0.002,-64) [-64|64.51] \"deg\" Vector__XXX\n" +
+		"    SG_ PitchAngle : 0|16@1+ (0.002,-64) [-64|64.51] \"deg\" Vector__XXX\n";
 
-//    @Test
+    @Test
     public void readEEC() throws IOException {
 
         Launcher.j1939_mode = true;
@@ -72,11 +72,10 @@ public class J1939modeTest {
         DbcFile dbc = ParseDBCTest.readDbc(dbcEEC + "\n\n" + dbcSSI);
 
         CANLineReader logReader = new PcanTrcReader1_1();
-        List<CANPacket> packets = List.of(
-                logReader.readLine("   5)        10.0  Rx     0CF00400  8  FF FF FF E8 25 FF FF 7D"),
-                logReader.readLine("  18)        30.0  Rx     0CF00400  8  FF FF FF 8C 26 FF FF 7D"),
-                logReader.readLine("  32)        50.0  Rx     0CF00400  8  FF FF FF 40 26 FF FF 7D")
-            );
+        List<CANPacket> packets = new ArrayList<>();
+        packets.add(logReader.readLine("   5)        10.0  Rx     0CF00400  8  FF FF FF E8 25 FF FF 7D"));
+        packets.add(logReader.readLine("  18)        30.0  Rx     0CF00400  8  FF FF FF 8C 26 FF FF 7D"));
+        packets.add(logReader.readLine("  32)        50.0  Rx     0CF00400  8  FF FF FF 40 26 FF FF 7D"));
 
         // dumb copy-paste from LoggingStrategy.writeLogByDbc()
 

--- a/reader/src/test/java/com/rusefi/can/reader/impl/J1939modeTest.java
+++ b/reader/src/test/java/com/rusefi/can/reader/impl/J1939modeTest.java
@@ -1,0 +1,94 @@
+package com.rusefi.can.reader.impl;
+
+import com.rusefi.can.CANPacket;
+import com.rusefi.can.Launcher;
+import com.rusefi.can.reader.CANLineReader;
+import com.rusefi.can.reader.dbc.DbcField;
+import com.rusefi.can.reader.dbc.DbcFile;
+import com.rusefi.can.reader.dbc.DbcPacket;
+import com.rusefi.mlv.LoggingStrategy;
+import com.rusefi.sensor_logs.BinaryLogEntry;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+
+public class J1939modeTest {
+
+    // xxF004xx
+    private static final String dbcEEC = """
+    BO_ 2364540158 EEC1: 8 Vector__XXX
+        SG_ EngDemandPercentTorque : 56|8@1+ (1,-125) [-125|125] "%" Vector__XXX
+        SG_ EngStarterMode : 48|4@1+ (1,0) [0|15] "" Vector__XXX
+        SG_ SrcAddrssOfCntrllngDvcForEngCtrl : 40|8@1+ (1,0) [0|253] "" Vector__XXX
+        SG_ EngSpeed : 24|16@1+ (0.125,0) [0|8031.875] "rpm" Vector__XXX
+        SG_ ActualEngPercentTorque : 16|8@1+ (1,-125) [0|125] "%" Vector__XXX
+        SG_ DriversDemandEngPercentTorque : 8|8@1+ (1,-125) [0|125] "%" Vector__XXX
+        SG_ ActlEngPrcntTorqueHighResolution : 4|4@1+ (0.125,0) [0|0.875] "%" Vector__XXX
+        SG_ EngTorqueMode : 0|4@1+ (1,0) [0|15] "" Vector__XXX""";
+
+    // xxF013xx
+    private static final String dbcSSI = """
+    BO_ 2364543998 SSI: 8 Vector__XXX
+        SG_ RollAndPitchMeasurementLatency : 56|8@1+ (0.5,0) [0|125] "ms" Vector__XXX
+        SG_ PitchAndRollCompensated : 54|2@1+ (1,0) [0|3] "" Vector__XXX
+        SG_ PitchRateFigureOfMerit : 52|2@1+ (1,0) [0|3] "" Vector__XXX
+        SG_ RollAngleFigureOfMerit : 50|2@1+ (1,0) [0|3] "" Vector__XXX
+        SG_ PitchAngleFigureOfMerit : 48|2@1+ (1,0) [0|3] "" Vector__XXX
+        SG_ PitchRate : 32|16@1+ (0.002,-64) [-64|64.51] "deg/s" Vector__XXX
+        SG_ RollAngle : 16|16@1+ (0.002,-64) [-64|64.51] "deg" Vector__XXX
+        SG_ PitchAngle : 0|16@1+ (0.002,-64) [-64|64.51] "deg" Vector__XXX""";
+
+//    @Test
+    public void readEEC() throws IOException {
+
+        Launcher.j1939_mode = true;
+        DbcFile dbc = ParseDBCTest.readDbc(dbcEEC);
+
+        String logLine = "     5)        10.0  Rx     0CF00400  8  FF FF FF E8 25 FF FF 7D \n";
+        CANPacket canPacket = new PcanTrcReader1_1().readLine(logLine);
+
+        DbcPacket dbcPkt = dbc.findPacket(canPacket.getId());
+        assertNotNull(dbcPkt);
+
+        // bytes 3,4, little endian
+        DbcField engSpeed = dbcPkt.find("EngSpeed");
+        assertNotNull(engSpeed);
+
+        assertEquals(0x25E8 * 0.125, engSpeed.getValue(canPacket), 0.1);
+
+        Launcher.j1939_mode = false;
+    }
+
+    @Test
+    public void megaLogFilter() throws IOException {
+        Launcher.j1939_mode = true;
+
+        DbcFile dbc = ParseDBCTest.readDbc(dbcEEC + "\n\n" + dbcSSI);
+
+        CANLineReader logReader = new PcanTrcReader1_1();
+        List<CANPacket> packets = List.of(
+                logReader.readLine("   5)        10.0  Rx     0CF00400  8  FF FF FF E8 25 FF FF 7D"),
+                logReader.readLine("  18)        30.0  Rx     0CF00400  8  FF FF FF 8C 26 FF FF 7D"),
+                logReader.readLine("  32)        50.0  Rx     0CF00400  8  FF FF FF 40 26 FF FF 7D")
+            );
+
+        // dumb copy-paste from LoggingStrategy.writeLogByDbc()
+
+        Set<Integer> allIds = CANPacket.getAllIds(packets);
+        // we only log DBC frames if at least one packet is present in the trace
+        LoggingStrategy.LoggingFilter filter = packet -> packet.isInLog(allIds);
+        List<BinaryLogEntry> entries = dbc.getFieldNameEntries(filter);
+
+        // in the entries we have the only EEC fields, but not SSI
+        assertTrue(entries.size() >= 8);    // EEC have 8 fields + 1 gap
+        assertTrue(entries.size() < 10);
+
+        Launcher.j1939_mode = false;
+    }
+}

--- a/reader/src/test/java/com/rusefi/can/reader/impl/ParseDBCTest.java
+++ b/reader/src/test/java/com/rusefi/can/reader/impl/ParseDBCTest.java
@@ -89,7 +89,7 @@ public class ParseDBCTest {
             "\n" +
             VAG_MOTOR_1;
 
-    private DbcFile readDbc(String text) throws IOException {
+    public static DbcFile readDbc(String text) throws IOException {
         BufferedReader reader = new BufferedReader(new StringReader(text));
         DbcFile dbc = new DbcFile(false);
         dbc.read(reader);

--- a/reader/src/test/java/com/rusefi/can/reader/impl/ParseDBCWithCommentTest.java
+++ b/reader/src/test/java/com/rusefi/can/reader/impl/ParseDBCWithCommentTest.java
@@ -39,9 +39,6 @@ public class ParseDBCWithCommentTest {
                     " SG_ Driving_Cycle : 4|1@1+ (1,0) [0|0] \"\" XXX\n" +
                     " SG_ Zaehler_Motor_Flexia : 1|3@1+ (1,0) [0|15] \"\" XXX\n" +
                     " SG_ Multiplex_Schalter_Motor_Flexia M : 0|1@1+ (1,0) [0|0] \"\" XXX\n" +
-                    "" +
-                    "" +
-                    "" +
                     "\n" +
                     "\n" +
                     "CM_ SG_ 1408 Zaehler_Motor_Flexia \"Counter Motor_Flexia\";\n" +
@@ -52,8 +49,7 @@ public class ParseDBCWithCommentTest {
                     "CM_ SG_ 1408 Anzahl_Zylinder \"Number of cylinders\";\n" +
                     "CM_ SG_ 1408 Anzahl_Ventile \"Number of valves\";\n" +
                     "CM_ SG_ 1408 Ansaugsystem \"Induction System\";\n" +
-                    "CM_ SG_ 1408 Motorleistung \"Maximum engine power\";\n" +
-                    "";
+                    "CM_ SG_ 1408 Motorleistung \"Maximum engine power\";\n";
 
     @Test
     public void parse() throws IOException {
@@ -62,9 +58,9 @@ public class ParseDBCWithCommentTest {
         DbcFile dbc = new DbcFile(LoggingStrategy.LOG_ONLY_TRANSLATED_FIELDS);
         dbc.read(reader);
 
-        assertEquals(dbc.size(), 1);
+        assertEquals(1, dbc.size());
         DbcPacket packet = dbc.findPacket(1408);
-        DbcField field = packet.find("Number of cylinders");
+        DbcField field = packet.find("Anzahl_Zylinder: Number of cylinders");
         assertNotNull(field);
         assertTrue(field.isNiceName());
     }


### PR DESCRIPTION
Adapt the tool to handle original (? at least, well known in the net) J1939 DBC files.

- mask unused bytes in the packet ID. For some reason DBC uses 0xFE for it, so we need to mask it as well
- don't throw exceptions in the GapFactory, if we have gaps longer than 8 bytes. Some packets in the J1939 use the same approach as UDS multipacket (one more layer to transport it) and therefore may be long enough.
- '?' and '*' in the comments are ok (and widely used in DBC), why you blocked it?

- comments in the DBC now handled in a different way: it's added to name, not replaced. Otherwise we have garbage in MegaLog when use something like this
`CM_ SG_ 2364540158 EngSpeed "Actual engine speed which is calculated over a minimum crankshaft angle of 720 degrees divided by the number of cylinders.";
`