### PR TITLE
ISO-TP: add check to not loose incomplete frame

### DIFF
--- a/reader/src/main/java/com/rusefi/io/can/isotp/IsoTpCanDecoder.java
+++ b/reader/src/main/java/com/rusefi/io/can/isotp/IsoTpCanDecoder.java
@@ -45,6 +45,9 @@ public abstract class IsoTpCanDecoder {
         int dataOffset;
         switch (frameType) {
             case IsoTpConstants.ISO_TP_FRAME_SINGLE:
+                if (this.waitingForNumBytes > 0) {
+                    throw new IllegalStateException("ISO_TP_FRAME_SINGLE: got new frame while previous is not complete");
+                }
                 numBytesAvailable = data[isoHeaderByteIndex] & 0xf;
                 dataOffset = isoHeaderByteIndex + 1;
                 this.waitingForNumBytes = 0;
@@ -53,6 +56,9 @@ public abstract class IsoTpCanDecoder {
                 setComplete(true);
                 break;
             case IsoTpConstants.ISO_TP_FRAME_FIRST:
+                if (this.waitingForNumBytes > 0) {
+                    throw new IllegalStateException("ISO_TP_FRAME_FIRST: got new frame while previous is not complete");
+                }
                 this.waitingForNumBytes = ((data[isoHeaderByteIndex] & 0xf) << 8) | (data[isoHeaderByteIndex + 1] & 0xFF);
                 if (log.debugEnabled())
                     log.debug("Total expected: " + waitingForNumBytes);

--- a/reader/src/test/java/com/rusefi/can/reader/isotp/IsoTpReaderSandbox.java
+++ b/reader/src/test/java/com/rusefi/can/reader/isotp/IsoTpReaderSandbox.java
@@ -1,11 +1,19 @@
 package com.rusefi.can.reader.isotp;
 
+import java.io.File;
 import java.io.IOException;
 
 public class IsoTpReaderSandbox {
     public static void main(String[] args) throws IOException {
-        String fileName = "C:\\stuff\\1\\b.trc";
+        //String fileName = "C:\\stuff\\1\\b.trc";
 
-        IsoTpFileDecoder.run(fileName);
+        //IsoTpFileDecoder.run(fileName);
+
+        String folder = "C:\\Projects\\Rusefi\\8hp\\can-traces\\unit-1";
+
+        String excludeProcessed = "^(?!processed).+\\.trc$";
+        for( File f : new File(folder).listFiles((dir, name) -> name.matches(excludeProcessed))){
+            IsoTpFileDecoder.run(f.getAbsolutePath());
+        }
     }
 }


### PR DESCRIPTION
it would be better to write an error if the last (or a few lasts) frames are lost somehow

Also added processing for the whole folder to sandbox