### PR TITLE
ISO-TP converter: add more settings

### DIFF
--- a/reader/src/main/java/com/rusefi/can/reader/isotp/IsoTpFileDecoder.java
+++ b/reader/src/main/java/com/rusefi/can/reader/isotp/IsoTpFileDecoder.java
@@ -13,15 +13,15 @@ import java.util.function.Function;
 
 public class IsoTpFileDecoder {
 
-    public static void run(String fileName, Set<Integer> isoTpIds) throws IOException {
+    public static void run(String fileName, Set<Integer> isoTpIds, int isoHeaderByteIndex) throws IOException {
         File f = new File(fileName);
 
         try (FileWriter fw = new FileWriter(f.getParent() + File.separator + "processed_" + f.getName())) {
-            process(fileName, fw, isoTpIds);
+            process(fileName, fw, isoTpIds, isoHeaderByteIndex);
         }
     }
 
-    private static void process(String fileName, FileWriter fw, Set<Integer> isoTpIds) throws IOException {
+    private static void process(String fileName, FileWriter fw, Set<Integer> isoTpIds, int isoHeaderByteIndex) throws IOException {
 
 
         List<CANPacket> packets = AutoFormatReader.INSTANCE.readFile(fileName);
@@ -39,7 +39,7 @@ public class IsoTpFileDecoder {
             IsoTpCanDecoder decoder = decoderById.computeIfAbsent(p.getId(), new Function<Integer, IsoTpCanDecoder>() {
                 @Override
                 public IsoTpCanDecoder apply(Integer integer) {
-                    return new IsoTpCanDecoder(1) {
+                    return new IsoTpCanDecoder(isoHeaderByteIndex) {
                         @Override
                         protected void onTpFirstFrame() {
 

--- a/reader/src/main/java/com/rusefi/can/reader/isotp/IsoTpFileDecoderFolderStrategy.java
+++ b/reader/src/main/java/com/rusefi/can/reader/isotp/IsoTpFileDecoderFolderStrategy.java
@@ -4,9 +4,19 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class IsoTpFileDecoderFolderStrategy {
+
+    static private final List<Integer> isoTpIds = Arrays.asList(
+            0x7DF,  // common UDS scanner broadcast
+            0x7E0, 0x7E1, 0x7E2, 0x7E3, 0x7E4, 0x7E5, 0x7E6, 0x7E7, // common UDS scanner
+            0x7E8, 0x7E9, 0x7EA, 0x7EB, 0x7EC, 0x7ED, 0x7EE, 0x7EF, // common UDS device
+            0x618,  // BMW EGS
+            0x6F1, 0x6F2, 0x6F3, 0x6F4  // BMW scanner
+    );
+    static private final int isoHeaderByteIndex = 1;    // 1 for BMW, 0 for standard UDS
 
     public static void main(String[] args) throws IOException {
         if (args.length != 1) {
@@ -17,10 +27,9 @@ public class IsoTpFileDecoderFolderStrategy {
     }
 
     private static void processFolder(String folder) throws IOException {
-        Set<Integer> isoTpIds = new HashSet<>(Arrays.asList(0x618, 0x6F4));
         String excludeProcessed = "^(?!processed).+\\.trc$";
         for (File f : new File(folder).listFiles((dir, name) -> name.matches(excludeProcessed))) {
-            IsoTpFileDecoder.run(f.getAbsolutePath(), isoTpIds);
+            IsoTpFileDecoder.run(f.getAbsolutePath(), new HashSet<>(isoTpIds), isoHeaderByteIndex);
         }
     }
 }


### PR DESCRIPTION
probably would be better to read `isoHeaderByteIndex` from command line, but at least now all parmeters located near `main` function